### PR TITLE
Fix wrongly detected conflict markers

### DIFF
--- a/all.bash
+++ b/all.bash
@@ -23,7 +23,7 @@ install_and_test(){
     HASGENBASH=$3
     echo
     echo
-    echo ">>> compiling $PKG <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    echo "=== compiling $PKG ============================================================="
     cd $PKG
     if [[ ! -z $HASGENBASH ]]; then
         ./xgenflagsfile.bash
@@ -63,4 +63,4 @@ install_and_test rnd 1
 #fi
 
 echo
-echo ">>> SUCCESS! <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+echo "=== SUCCESS! ============================================================"


### PR DESCRIPTION
When adding gosl as a vendored dependency in a gerrit-supervised repo, one would get this error:

> ! [remote rejected] HEAD -> refs/for/master (XXXXX contains conflict markers)

This simple change fixes that.