### PR TITLE
Fixed: -lgfortran brew source directory

### DIFF
--- a/num/qpck/flags.go
+++ b/num/qpck/flags.go
@@ -9,6 +9,6 @@ package qpck
 
 #cgo windows LDFLAGS: -lopenblas -lgfortran -lm
 
-#cgo darwin LDFLAGS: -L/usr/local/opt/openblas/lib -L/usr/local/Cellar/gcc/7.1.0/lib/gcc/7/ -lopenblas -lgfortran -lm
+#cgo darwin LDFLAGS: -L/usr/local/opt/openblas/lib -L/usr/local/Cellar/gcc/7.3.0/lib/gcc/7/ -lopenblas -lgfortran -lm
 */
 import "C"


### PR DESCRIPTION
Using `brew install gcc`, the gcc version diverges. In fact, gosl uses version 7.1.0 and the package manager "brew" installs version 7.3.0.

After testing, I propose this pull request to modify the flags in `gosl/num/qpck`.