### PR TITLE
support mpi on darwin

### DIFF
--- a/mpi/flags_darwin.go
+++ b/mpi/flags_darwin.go
@@ -1,0 +1,19 @@
+// Copyright 2016 The Gosl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows,!linux
+
+package mpi
+
+/*
+#cgo CFLAGS: -O2 -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent/include -I/usr/lib/openmpi/include -I/usr/lib/openmpi/include/openmpi -I/usr/include/openmpi -pthread
+#cgo LDFLAGS: -pthread -lmpi
+*/
+import "C"
+
+// NOTE: get flags with:
+//
+//   mpicc hello_c.c -showme:compile
+//
+//   mpicc hello_c.c -showme:link

--- a/mpi/mpi.go
+++ b/mpi/mpi.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !windows,!darwin
+// +build !windows
 
 // Package mpi wraps the Message Passing Interface for parallel computations
 package mpi

--- a/mpi/mpi_notlinux.go
+++ b/mpi/mpi_notlinux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !linux
+// +build !linux,!darwin
 
 // Package mpi wraps the Message Passing Interface for parallel computations
 package mpi

--- a/mpi/t_mpi_test.go
+++ b/mpi/t_mpi_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !windows,!darwin
+// +build !windows
 
 package mpi
 


### PR DESCRIPTION
Ref #20 - this PR enables mpi on darwin. Testing with openmpi installed via homebrew (`brew install openmpi`).