### PR TITLE
Adding macos cgo flags for mkl

### DIFF
--- a/la/mkl/flags.go
+++ b/la/mkl/flags.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !darwin,amd64
+
 package mkl
 
 /*

--- a/la/mkl/flags_darwin_amd64.go
+++ b/la/mkl/flags_darwin_amd64.go
@@ -1,0 +1,12 @@
+// Copyright 2016 The Gosl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mkl
+
+/*
+#cgo CFLAGS: -O2  -DMKL_ILP64 -m64 -I/opt/intel/mkl/include
+#cgo LDFLAGS: -L/opt/intel/lib /opt/intel/mkl/lib/libmkl_intel_ilp64.a /opt/intel/mkl/lib/libmkl_intel_thread.a /opt/intel/mkl/lib/libmkl_core.a /opt/intel/lib/libiomp5.a -lpthread -lm -ldl
+
+*/
+import "C"


### PR DESCRIPTION
Hey I was trying to use the mkl lib on macos and was getting some cgo errors:

```
jason@mba ~/go/src/github.com/jasonmoo/gosl/la/mkl master: go test -v
# github.com/jasonmoo/gosl/la/mkl
clang: error: no such file or directory: '/opt/intel/mkl/lib/intel64/libmkl_intel_ilp64.a'
clang: error: no such file or directory: '/opt/intel/mkl/lib/intel64/libmkl_intel_thread.a'
clang: error: no such file or directory: '/opt/intel/mkl/lib/intel64/libmkl_core.a'
clang: error: no such file or directory: '/opt/intel/lib/intel64/libiomp5.a'
FAIL	github.com/jasonmoo/gosl/la/mkl [build failed]
```

This is using the default installation of Intel MKL from the dmg installer on their site.

I changed the build flags to work with darwin and updated the build tags to prevent conflicts.  Feel free to merge if you find useful.  I am not an expert at cgo flags so perhaps other eyes will see a better solution.