### PR TITLE
Use openblas header from local directory

### DIFF
--- a/la/oblas/oblas.go
+++ b/la/oblas/oblas.go
@@ -19,7 +19,7 @@
 package oblas
 
 /*
-#include <openblas_cblas.h>
+#include "openblas_cblas.h"
 #include <lapacke.h>
 
 static inline double* cpt(double complex* p) { return (double*)p; }


### PR DESCRIPTION
When running `./all.bash` from the project root, after following the installation instructions on both macOS and debian jessie, I get the error:

```
fatal error: openblas_cblas.h: No such file or directory
#include <openblas_cblas.h>
```

This is because that file, in both my environments, doesn't exist in any of my lib dirs- despite the installation(s) completing without error.

Given that this file exists in the repo, shifting the `<>` to quotes allows me to load from there instead.

In this case, the build passes.