### PR TITLE
Use the PYTHON environment variable to determine python binary

### DIFF
--- a/plt/mplotlib.go
+++ b/plt/mplotlib.go
@@ -792,9 +792,13 @@ func run(fn string) {
 
 	// write file
 	io.WriteFile(TemporaryDir, &bufferEa, &bufferPy)
+	python := os.Getenv("PYTHON")
+	if python == "" {
+		python = "python"
+	}
 
 	// set command
-	cmd := exec.Command("python", TemporaryDir)
+	cmd := exec.Command(python, TemporaryDir)
 	var out, serr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &serr


### PR DESCRIPTION
The python program in the default path may not be equipped to run
matplotlib, so read the PYTHON environment variable to find the
desired python interpreter to use and if it is not set, fall back to
`python`.