### PR TITLE
vtk: Fix a build error about returning from non-void function

### DIFF
--- a/vtk/v_sgrid.h
+++ b/vtk/v_sgrid.h
@@ -57,7 +57,7 @@ public:
     void SetPoint (int i, const double x[3]) { if (_initialized) _points->SetPoint(i, x); }
     
     // Additional access methods
-    vtkStructuredGrid * GetGrid() const { if (_initialized) return _sgrid; }
+    vtkStructuredGrid * GetGrid() const { if (_initialized) return _sgrid; return NULL; }
 
     // Methods
     void ShowWire    ()             { if (_initialized) _sgrid_actor->GetProperty()->SetRepresentationToWireframe(); }


### PR DESCRIPTION
Add a default fallback for the GetGrid function in v_sgrid.h to avoid
the following warning:

```
In file included from v_isosurf.h:18,
                 from connectgovtk.cpp:19:
v_sgrid.h: In member function ‘vtkStructuredGrid* GoslVTK::SGrid::GetGrid() const’:
v_sgrid.h:60:76: warning: control reaches end of non-void function [-Wreturn-type]
     vtkStructuredGrid * GetGrid() const { if (_initialized) return _sgrid; }
                                                                            ^
```