### PR TITLE
Bump up tolerance for A-B for EqCubicSolveReal

### DIFF
--- a/num/cubicequation.go
+++ b/num/cubicequation.go
@@ -23,7 +23,7 @@ import (
 func EqCubicSolveReal(a, b, c float64) (x1, x2, x3 float64, nx int) {
 
 	// tolerance
-	ϵ := 1e-14
+	ϵ := 1.4e-9
 
 	// auxiliary
 	aa := a * a


### PR DESCRIPTION
The Test_cubiceq02 test (rightly) expects EqCubicSolveReal to return 2
real results for the equation `y(x) = x³ + x²` but this fails on
arm64.  This is because the error tolerance for A-B (i.e. the
imaginary component of the two roots) is set to 1e-14, which is too
low for arm64, which produces an error of the order of 1e-9.

Tolerate a slightly higher error value in the interest of getting a
correct result on arm64.