### PR TITLE
Enable mpi for freebsd

### DIFF
--- a/mpi/flags.go
+++ b/mpi/flags.go
@@ -12,5 +12,8 @@ package mpi
 
 #cgo darwin CFLAGS: -I/usr/local/Cellar/open-mpi/4.0.1_2/include
 #cgo darwin LDFLAGS: -L/usr/local/opt/libevent/lib -L/usr/local/Cellar/open-mpi/4.0.1_2/lib -lmpi
+
+#cgo freebsd CFLAGS: -I/usr/local/include
+#cgo freebsd LDFLAGS: -L/usr/local/lib -lmpi
 */
 import "C"

--- a/mpi/mpi_notlinux.go
+++ b/mpi/mpi_notlinux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !linux,!darwin
+// +build !linux,!darwin,!freebsd
 
 // Package mpi wraps the Message Passing Interface for parallel computations
 package mpi


### PR DESCRIPTION
The mpi library works under FreeBSD, too. There is just a build tag missing.