### PR TITLE
umfErr should take an int, not a long

### DIFF
--- a/la/sparse_conversions.go
+++ b/la/sparse_conversions.go
@@ -79,7 +79,7 @@ func (t *TripletC) ToMatrix(a *CCMatrixC) *CCMatrixC {
 }
 
 // umfErr returns UMFPACK error codes
-func umfErr(code C.LONG) string {
+func umfErr(code C.int) string {
 	switch code {
 	case C.UMFPACK_ERROR_out_of_memory:
 		return "out_of_memory (-1)"


### PR DESCRIPTION
The current project fails to work on 64-bit linux machines, as the CGo functions which call `umfErr` pass `C.int` values, not `C.LONG`.

This PR updates `umfErr` to properly handle these values.